### PR TITLE
Add owners annotation to Chart.yaml for routing alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `application.giantswarm.io/owners` annotation to Chart.yaml for routing
+alerts.
+
 ## [1.0.3] - 2020-12-13
 
 ### Fixed

--- a/helm/vertical-pod-autoscaler-app/Chart.yaml
+++ b/helm/vertical-pod-autoscaler-app/Chart.yaml
@@ -7,3 +7,13 @@ name: vertical-pod-autoscaler-app
 sources:
 - https://github.com/kubernetes/autoscaler
 version: [[ .Version ]]
+annotations:
+  application.giantswarm.io/owners: |
+    - catalog: control-plane-catalog
+      team: atlas
+    - catalog: control-plane-test-catalog
+      team: atlas
+    - catalog: giantswarm-playground
+      team: halo
+    - catalog: giantswarm-playground-test
+      team: halo


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14846

This tests out the owner annotation and routing by catalog.

Halo this will set the team label to halo if its the playground catalog but the alerts will still route to #alert-batman.

```sh
kg port-forward app-exporter-unique-6b4bf4b6b9-9ccnd 8000:8000
curl -s http://localhost:8000/metrics | grep vertical-pod-autoscaler

app_operator_app_info{app="vertical-pod-autoscaler-app",catalog="control-plane-test-catalog",name="vertical-pod-autoscaler-app-unique",namespace="giantswarm",status="deployed",team="atlas",version="1.0.3-34f640ce5923400be18ef9b5d22b85435c2f5f85"} 1
```

EDIT: Forgot to mention playground catalog. 🤦‍♂️ 
