### PR TITLE
set admission-controller log-level=3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change log-level from default=4 to 3.
+
 ## [2.1.2] - 2022-02-23
 
 ### Fixed

--- a/helm/vertical-pod-autoscaler-app/templates/admission-controller-deployment.yaml
+++ b/helm/vertical-pod-autoscaler-app/templates/admission-controller-deployment.yaml
@@ -37,6 +37,8 @@ spec:
           securityContext:
             {{- toYaml .Values.admissionController.securityContext | nindent 12 }}
           image: "{{ .Values.registry.domain }}/{{ .Values.admissionController.image.repository }}:{{ .Values.admissionController.image.tag | default .Chart.AppVersion }}"
+          args:
+          - -v=3
           imagePullPolicy: {{ .Values.admissionController.image.pullPolicy }}
           volumeMounts:
             - name: tls-certs


### PR DESCRIPTION
Changing log-level from default=4 to 3, because otherwise its unreadable.

#### Before

![image](https://user-images.githubusercontent.com/6536819/155363315-d619d9e3-d702-49f8-ae23-77b7c51f7a8e.png)

#### After

![image](https://user-images.githubusercontent.com/6536819/155363386-a307ebf4-aeec-405f-911c-1ccbd0c78c50.png)
