### PR TITLE
add release name prefix to resource names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Change log-level from default=4 to 3.
+- Rename resources to include release name as prefix and avoid name collision.
 
 ## [2.1.2] - 2022-02-23
 

--- a/helm/vertical-pod-autoscaler-app/templates/admission-controller-rbac.yaml
+++ b/helm/vertical-pod-autoscaler-app/templates/admission-controller-rbac.yaml
@@ -4,7 +4,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: vpa-admission-controller
+  name: {{ include "vpa.fullname" . }}-admission-controller
   labels:
     {{- include "vpa.labels" . | nindent 4 }}
 rules:
@@ -58,13 +58,13 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: vpa-admission-controller
+  name: {{ include "vpa.fullname" . }}-admission-controller
   labels:
     {{- include "vpa.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: vpa-admission-controller
+  name: {{ include "vpa.fullname" . }}-admission-controller
 subjects:
   - kind: ServiceAccount
     name: {{ include "vpa.serviceAccountName" . }}-admission-controller

--- a/helm/vertical-pod-autoscaler-app/templates/admission-controller-service.yaml
+++ b/helm/vertical-pod-autoscaler-app/templates/admission-controller-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: vpa-webhook
+  name: {{ include "vpa.fullname" . }}-webhook
   labels:
     app.kubernetes.io/component: admission-controller
     {{- include "vpa.labels" . | nindent 4 }}

--- a/helm/vertical-pod-autoscaler-app/templates/clusterrolebindings.yaml
+++ b/helm/vertical-pod-autoscaler-app/templates/clusterrolebindings.yaml
@@ -5,13 +5,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: vpa-metrics-reader
+  name: {{ include "vpa.fullname" . }}-metrics-reader
   labels:
     {{- include "vpa.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: vpa-metrics-reader
+  name: {{ include "vpa.fullname" . }}-metrics-reader
 subjects:
   - kind: ServiceAccount
     name: {{ include "vpa.serviceAccountName" . }}-recommender
@@ -20,13 +20,13 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: vpa-checkpoint-actor
+  name: {{ include "vpa.fullname" . }}-checkpoint-actor
   labels:
     {{- include "vpa.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: vpa-checkpoint-actor
+  name: {{ include "vpa.fullname" . }}-checkpoint-actor
 subjects:
   - kind: ServiceAccount
     name: {{ include "vpa.serviceAccountName" . }}-recommender
@@ -38,13 +38,13 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: vpa-evictionter-binding
+  name: {{ include "vpa.fullname" . }}-evictionter-binding
   labels:
     {{- include "vpa.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: vpa-evictioner
+  name: {{ include "vpa.fullname" . }}-evictioner
 subjects:
   - kind: ServiceAccount
     name: {{ include "vpa.serviceAccountName" . }}-updater
@@ -53,13 +53,13 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: vpa-status-reader-binding
+  name: {{ include "vpa.fullname" . }}-status-reader-binding
   labels:
     {{- include "vpa.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: vpa-status-reader
+  name: {{ include "vpa.fullname" . }}-status-reader
 subjects:
   - kind: ServiceAccount
     name: {{ include "vpa.serviceAccountName" . }}-updater
@@ -71,13 +71,13 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: vpa-actor
+  name: {{ include "vpa.fullname" . }}-actor
   labels:
     {{- include "vpa.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: vpa-actor
+  name: {{ include "vpa.fullname" . }}-actor
 subjects:
 {{- if .Values.recommender.enabled }}
   - kind: ServiceAccount
@@ -96,13 +96,13 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: vpa-target-reader-binding
+  name: {{ include "vpa.fullname" . }}-target-reader-binding
   labels:
     {{- include "vpa.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: vpa-target-reader
+  name: {{ include "vpa.fullname" . }}-target-reader
 subjects:
 {{- if .Values.recommender.enabled }}
   - kind: ServiceAccount

--- a/helm/vertical-pod-autoscaler-app/templates/clusterroles.yaml
+++ b/helm/vertical-pod-autoscaler-app/templates/clusterroles.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: vpa-metrics-reader
+  name: {{ include "vpa.fullname" . }}-metrics-reader
   labels:
     {{- include "vpa.labels" . | nindent 4 }}
 rules:
@@ -18,7 +18,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: vpa-actor
+  name: {{ include "vpa.fullname" . }}-actor
   labels:
     {{- include "vpa.labels" . | nindent 4 }}
 rules:
@@ -63,7 +63,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: vpa-checkpoint-actor
+  name: {{ include "vpa.fullname" . }}-checkpoint-actor
   labels:
     {{- include "vpa.labels" . | nindent 4 }}
 rules:
@@ -100,7 +100,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: vpa-evictioner
+  name: {{ include "vpa.fullname" . }}-evictioner
   labels:
     {{- include "vpa.labels" . | nindent 4 }}
 rules:
@@ -121,7 +121,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: vpa-target-reader
+  name: {{ include "vpa.fullname" . }}-target-reader
   labels:
     {{- include "vpa.labels" . | nindent 4 }}
 rules:
@@ -164,7 +164,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: vpa-status-reader
+  name: {{ include "vpa.fullname" . }}-status-reader
   labels:
     {{- include "vpa.labels" . | nindent 4 }}
 rules:


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/21463

Add helm release name as prefix for resources name that were missing it. This is to avoid name collision.