### PR TITLE
upgrade 0.10.0

### DIFF
--- a/helm/vertical-pod-autoscaler-app/Chart.yaml
+++ b/helm/vertical-pod-autoscaler-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.9.2
+appVersion: 0.10.0
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 home: https://github.com/giantswarm/vertical-pod-autoscaler-app
 maintainers:

--- a/helm/vertical-pod-autoscaler-app/README.md
+++ b/helm/vertical-pod-autoscaler-app/README.md
@@ -65,6 +65,7 @@ recommender:
 | priorityClassName | string | `""` | To set the priorityclass for all pods |
 | nameOverride | string | `""` | A template override for the name |
 | fullnameOverride | string | `""` | A template override for the fullname |
+| podLabels | object | `{}` | Labels to add to all pods |
 | rbac.create | bool | `true` | If true, then rbac resources (clusterroles and clusterrolebindings) will be created for the selected components. |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created for each component |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service accounts for each component |
@@ -78,6 +79,7 @@ recommender:
 | recommender.image.pullPolicy | string | `"Always"` | The pull policy for the recommender image. Recommend not changing this |
 | recommender.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
 | recommender.podAnnotations | object | `{}` | Annotations to add to the recommender pod |
+| recommender.podLabels | object | `{}` | Labels to add to the recommender pod |
 | recommender.podSecurityContext.runAsNonRoot | bool | `true` |  |
 | recommender.podSecurityContext.runAsUser | int | `65534` |  |
 | recommender.securityContext | object | `{}` | The security context for the containers inside the recommender pod |
@@ -93,6 +95,7 @@ recommender:
 | updater.image.pullPolicy | string | `"Always"` | The pull policy for the updater image. Recommend not changing this |
 | updater.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
 | updater.podAnnotations | object | `{}` | Annotations to add to the updater pod |
+| updater.podLabels | object | `{}` | Labels to add to the updater pod |
 | updater.podSecurityContext.runAsNonRoot | bool | `true` |  |
 | updater.podSecurityContext.runAsUser | int | `65534` |  |
 | updater.securityContext | object | `{}` | The security context for the containers inside the updater pod |
@@ -101,6 +104,7 @@ recommender:
 | updater.tolerations | list | `[]` |  |
 | updater.affinity | object | `{}` |  |
 | admissionController.enabled | bool | `false` | If true, will install the admission-controller component of vpa |
+| admissionController.extraArgs | object | `{}` | A key-value map of flags to pass to the admissionController |
 | admissionController.generateCertificate | bool | `true` | If true and admissionController is enabled, a pre-install hook will run to create the certificate for the webhook |
 | admissionController.certGen.image.repository | string | `"quay.io/reactiveops/ci-images"` | An image that contains certgen for creating certificates. Only used if admissionController.generateCertificate is true |
 | admissionController.certGen.image.tag | string | `"v11-alpine"` | An image tag for the admissionController.certGen.image.repository image. Only used if admissionController.generateCertificate is true |
@@ -116,10 +120,12 @@ recommender:
 | admissionController.image.pullPolicy | string | `"Always"` | The pull policy for the admission controller image. Recommend not changing this |
 | admissionController.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
 | admissionController.podAnnotations | object | `{}` | Annotations to add to the admission controller pod |
+| admissionController.podLabels | object | `{}` | Labels to add to the admission controller pod |
 | admissionController.podSecurityContext.runAsNonRoot | bool | `true` |  |
 | admissionController.podSecurityContext.runAsUser | int | `65534` |  |
 | admissionController.securityContext | object | `{}` | The security context for the containers inside the admission controller pod |
 | admissionController.resources | object | `{"limits":{"cpu":"200m","memory":"500Mi"},"requests":{"cpu":"50m","memory":"200Mi"}}` | The resources block for the admission controller pod |
+| admissionController.tlsSecretKeys | list | `[]` | The keys in the vpa-tls-certs secret to map in to the admission controller |
 | admissionController.nodeSelector | object | `{}` |  |
 | admissionController.tolerations | list | `[]` |  |
 | admissionController.affinity | object | `{}` |  |

--- a/helm/vertical-pod-autoscaler-app/ci/test-values.yaml
+++ b/helm/vertical-pod-autoscaler-app/ci/test-values.yaml
@@ -1,11 +1,25 @@
 testMode: true
 recommender:
   enabled: true
+  podLabels:
+    app: test
+    foo: bar
 updater:
   enabled: true
+  podLabels:
+    app: test
+    foo: bar
 admissionController:
   enabled: true
+  extraArgs:
+    v: "4"
   generateCertificate: true
   certGen:
     env:
       ENVIRONMENTVARIABLE: exists
+  podLabels:
+    app: test
+    foo: bar
+podLabels:
+  app: test
+  foo: bar

--- a/helm/vertical-pod-autoscaler-app/templates/_helpers.tpl
+++ b/helm/vertical-pod-autoscaler-app/templates/_helpers.tpl
@@ -39,6 +39,9 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 giantswarm.io/service-type: "managed"
 helm.sh/chart: {{ include "vpa.chart" . }}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/helm/vertical-pod-autoscaler-app/templates/admission-controller-certgen.yaml
+++ b/helm/vertical-pod-autoscaler-app/templates/admission-controller-certgen.yaml
@@ -54,6 +54,10 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: {{ include "vpa.fullname" . }}-certgen
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: certgen
         image: "{{ .Values.registry.domain }}/{{ .Values.admissionController.certGen.image.repository }}:{{ .Values.admissionController.certGen.image.tag }}"

--- a/helm/vertical-pod-autoscaler-app/templates/admission-controller-cleanup.yaml
+++ b/helm/vertical-pod-autoscaler-app/templates/admission-controller-cleanup.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.admissionController.cleanupOnDelete.enabled }}
+{{- if and .Values.admissionController.cleanupOnDelete.enabled .Values.admissionController.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
@@ -52,6 +52,10 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: {{ include "vpa.fullname" . }}-cleanup
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: cleanup
         image: {{ .Values.registry.domain }}/{{ .Values.admissionController.cleanupOnDelete.image.repository }}:{{ .Values.admissionController.cleanupOnDelete.image.tag }}

--- a/helm/vertical-pod-autoscaler-app/templates/admission-controller-deployment.yaml
+++ b/helm/vertical-pod-autoscaler-app/templates/admission-controller-deployment.yaml
@@ -19,6 +19,9 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       labels:
+      {{- with .Values.admissionController.podLabels }}
+          {{- toYaml . | nindent 8 }}
+      {{- end }}
         app.kubernetes.io/component: admission-controller
         {{- include "vpa.selectorLabels" . | nindent 8 }}
     spec:
@@ -40,6 +43,12 @@ spec:
           args:
           - -v=3
           imagePullPolicy: {{ .Values.admissionController.image.pullPolicy }}
+          {{- if .Values.admissionController.extraArgs }}
+          args:
+          {{- range $key, $value := .Values.admissionController.extraArgs }}
+            - --{{ $key }}={{ $value }}
+          {{- end }}
+          {{- end }}
           volumeMounts:
             - name: tls-certs
               mountPath: "/etc/tls-certs"
@@ -80,6 +89,10 @@ spec:
         - name: tls-certs
           secret:
             secretName: vpa-tls-certs
+            {{- with .Values.admissionController.tlsSecretKeys }}
+            items:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
       {{- with .Values.admissionController.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/vertical-pod-autoscaler-app/templates/recommender-deployment.yaml
+++ b/helm/vertical-pod-autoscaler-app/templates/recommender-deployment.yaml
@@ -19,6 +19,9 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       labels:
+      {{- with .Values.recommender.podLabels }}
+          {{- toYaml . | nindent 8 }}
+      {{- end }}
         app.kubernetes.io/component: recommender
         {{- include "vpa.selectorLabels" . | nindent 8 }}
     spec:

--- a/helm/vertical-pod-autoscaler-app/templates/updater-deployment.yaml
+++ b/helm/vertical-pod-autoscaler-app/templates/updater-deployment.yaml
@@ -19,6 +19,9 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       labels:
+      {{- with .Values.updater.podLabels }}
+          {{- toYaml . | nindent 8 }}
+      {{- end }}
         app.kubernetes.io/component: updater
         {{- include "vpa.selectorLabels" . | nindent 8 }}
     spec:

--- a/helm/vertical-pod-autoscaler-app/values.yaml
+++ b/helm/vertical-pod-autoscaler-app/values.yaml
@@ -10,6 +10,8 @@ priorityClassName: ""
 nameOverride: ""
 # fullnameOverride -- A template override for the fullname
 fullnameOverride: ""
+# podLabels -- Labels to add to all pods
+podLabels: {}
 rbac:
   # rbac.create -- If true, then rbac resources (clusterroles and clusterrolebindings) will be created for the selected components.
   create: true
@@ -49,6 +51,8 @@ recommender:
     tag: ""
   # recommender.podAnnotations -- Annotations to add to the recommender pod
   podAnnotations: {}
+  # recommender.podLabels -- Labels to add to the recommender pod
+  podLabels: {}
   # recommender.podSecurityContetxt -- The security context for the recommender pod
   podSecurityContext:
     runAsNonRoot: true
@@ -89,6 +93,8 @@ updater:
     tag: ""
   # updater.podAnnotations -- Annotations to add to the updater pod
   podAnnotations: {}
+  # updater.podLabels -- Labels to add to the updater pod
+  podLabels: {}
   # updater.podSecurityContetxt -- The security context for the updater pod
   podSecurityContext:
     runAsNonRoot: true
@@ -110,6 +116,8 @@ updater:
 admissionController:
   # admissionController.enabled -- If true, will install the admission-controller component of vpa
   enabled: true
+  # admissionController.extraArgs -- A key-value map of flags to pass to the admissionController
+  extraArgs: {}
   # admissionController.generateCertificate -- If true and admissionController is enabled, a pre-install hook will run to create the certificate for the webhook
   generateCertificate: true
   certGen:
@@ -147,6 +155,8 @@ admissionController:
     tag: ""
   # admissionController.podAnnotations -- Annotations to add to the admission controller pod
   podAnnotations: {}
+  # admissionController.podLabels -- Labels to add to the admission controller pod
+  podLabels: {}
   # admissionController.podSecurityContetxt -- The security context for the admission controller pod
   podSecurityContext:
     runAsNonRoot: true
@@ -161,6 +171,14 @@ admissionController:
     requests:
       cpu: 50m
       memory: 200Mi
+  # admissionController.tlsSecretKeys -- The keys in the vpa-tls-certs secret to map in to the admission controller
+  tlsSecretKeys: []
+    # - key: ca.crt
+    #   path: caCert.pem
+    # - key: tls.crt
+    #   path: serverCert.pem
+    # - key: tls.key
+    #   path: serverKey.pem
   nodeSelector: {}
   tolerations: []
   affinity: {}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/21463

Upgrading the chart to latest [master](https://github.com/FairwindsOps/charts/tree/a85a5f646fbf892155955d86e6963c42f4e45211) which contains the `extraArgs` option for `admission-controller`, we need this to be able to label our resources correctly and not break `admission-controller` so we can configure the `webhook-service` arg https://github.com/kubernetes/autoscaler/blob/6e7f36fe36fb1752dbe4b4204ca3f965486cb97b/vertical-pod-autoscaler/pkg/admission-controller/main.go#L64

