### PR TITLE
fix admission-controller webhook-service name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix admission-controller webhook-service name.
+
 ## [2.2.0] - 2022-05-04
 
 ### Changed

--- a/helm/vertical-pod-autoscaler-app/templates/admission-controller-deployment.yaml
+++ b/helm/vertical-pod-autoscaler-app/templates/admission-controller-deployment.yaml
@@ -42,14 +42,13 @@ spec:
           image: "{{ .Values.registry.domain }}/{{ .Values.admissionController.image.repository }}:{{ .Values.admissionController.image.tag | default .Chart.AppVersion }}"
           args:
           - -v=3
-          imagePullPolicy: {{ .Values.admissionController.image.pullPolicy }}
-          args:
-            - --webhook-service: {{ include "vpa.fullname" . }}-webhook
+          - --webhook-service: {{ include "vpa.fullname" . }}-webhook
           {{- if .Values.admissionController.extraArgs }}
           {{- range $key, $value := .Values.admissionController.extraArgs }}
-            - --{{ $key }}={{ $value }}
+          - --{{ $key }}={{ $value }}
           {{- end }}
           {{- end }}
+          imagePullPolicy: {{ .Values.admissionController.image.pullPolicy }}
           volumeMounts:
             - name: tls-certs
               mountPath: "/etc/tls-certs"

--- a/helm/vertical-pod-autoscaler-app/templates/admission-controller-deployment.yaml
+++ b/helm/vertical-pod-autoscaler-app/templates/admission-controller-deployment.yaml
@@ -42,7 +42,7 @@ spec:
           image: "{{ .Values.registry.domain }}/{{ .Values.admissionController.image.repository }}:{{ .Values.admissionController.image.tag | default .Chart.AppVersion }}"
           args:
           - -v=3
-          - --webhook-service: {{ include "vpa.fullname" . }}-webhook
+          - --webhook-service={{ include "vpa.fullname" . }}-webhook
           {{- if .Values.admissionController.extraArgs }}
           {{- range $key, $value := .Values.admissionController.extraArgs }}
           - --{{ $key }}={{ $value }}

--- a/helm/vertical-pod-autoscaler-app/templates/admission-controller-deployment.yaml
+++ b/helm/vertical-pod-autoscaler-app/templates/admission-controller-deployment.yaml
@@ -43,8 +43,9 @@ spec:
           args:
           - -v=3
           imagePullPolicy: {{ .Values.admissionController.image.pullPolicy }}
-          {{- if .Values.admissionController.extraArgs }}
           args:
+            - --webhook-service: {{ include "vpa.fullname" . }}-webhook
+          {{- if .Values.admissionController.extraArgs }}
           {{- range $key, $value := .Values.admissionController.extraArgs }}
             - --{{ $key }}={{ $value }}
           {{- end }}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/21463

Set the `webhook-service` name to correct value, after renaming resources.

Realizing now and too late that we do not need the upgrade to 0.10.0 to do this.