### PR TITLE
Fix generated secret certificate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix webhook name in generated secret certificate.
+- Prefix generated secret certificate with release-name.
 
 ## [2.2.0] - 2022-05-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix webhook name in generated secret certificate.
+
 ## [2.2.0] - 2022-05-04
 
 ### Changed

--- a/helm/vertical-pod-autoscaler-app/templates/admission-controller-certgen.yaml
+++ b/helm/vertical-pod-autoscaler-app/templates/admission-controller-certgen.yaml
@@ -91,7 +91,7 @@ spec:
             basicConstraints = CA:FALSE
             keyUsage = nonRepudiation, digitalSignature, keyEncipherment
             extendedKeyUsage = clientAuth, serverAuth
-            subjectAltName = DNS:vpa-webhook.{{ .Release.Namespace }}.svc
+            subjectAltName = DNS:{{ include "vpa.fullname" . }}-webhook.{{ .Release.Namespace }}.svc
             EOF
 
             # Create a certificate authority
@@ -107,7 +107,7 @@ spec:
             # Create a server certiticate
             openssl genrsa -out ${TMP_DIR}/serverKey.pem 2048
             # Note the CN is the DNS name of the service of the webhook.
-            openssl req -new -key ${TMP_DIR}/serverKey.pem -out ${TMP_DIR}/server.csr -subj "/CN=vpa-webhook.{{ .Release.Namespace }}.svc" -config ${TMP_DIR}/server.conf -addext "subjectAltName = DNS:vpa-webhook.{{ .Release.Namespace }}.svc"
+            openssl req -new -key ${TMP_DIR}/serverKey.pem -out ${TMP_DIR}/server.csr -subj "/CN={{ include "vpa.fullname" . }}-webhook.{{ .Release.Namespace }}.svc" -config ${TMP_DIR}/server.conf -addext "subjectAltName = DNS:{{ include "vpa.fullname" . }}-webhook.{{ .Release.Namespace }}.svc"
             openssl x509 -req -in ${TMP_DIR}/server.csr -CA ${TMP_DIR}/caCert.pem -CAkey ${TMP_DIR}/caKey.pem -CAcreateserial -out ${TMP_DIR}/serverCert.pem -days 100000 -extensions SAN -extensions v3_req -extfile ${TMP_DIR}/server.conf
 
             echo "Uploading certs to the cluster."

--- a/helm/vertical-pod-autoscaler-app/templates/admission-controller-certgen.yaml
+++ b/helm/vertical-pod-autoscaler-app/templates/admission-controller-certgen.yaml
@@ -76,8 +76,8 @@ spec:
             CN_BASE="vpa_webhook"
             TMP_DIR="/tmp/vpa-certs"
 
-            if kubectl get secret -n {{ .Release.Namespace }} vpa-tls-certs; then
-              echo "Secret vpa-tls-secrets already exists in namespace {{ .Release.Namespace }}"
+            if kubectl get secret -n {{ .Release.Namespace }} {{ include "vpa.fullname" . }}-tls-certs; then
+              echo "Secret {{ include "vpa.fullname" . }}-tls-secrets already exists in namespace {{ .Release.Namespace }}"
               exit 0
             fi
             echo "Generating certs for the VPA Admission Controller in ${TMP_DIR}."
@@ -111,7 +111,7 @@ spec:
             openssl x509 -req -in ${TMP_DIR}/server.csr -CA ${TMP_DIR}/caCert.pem -CAkey ${TMP_DIR}/caKey.pem -CAcreateserial -out ${TMP_DIR}/serverCert.pem -days 100000 -extensions SAN -extensions v3_req -extfile ${TMP_DIR}/server.conf
 
             echo "Uploading certs to the cluster."
-            kubectl create secret --namespace={{ .Release.Namespace }} generic vpa-tls-certs --from-file=${TMP_DIR}/caKey.pem --from-file=${TMP_DIR}/caCert.pem --from-file=${TMP_DIR}/serverKey.pem --from-file=${TMP_DIR}/serverCert.pem
+            kubectl create secret --namespace={{ .Release.Namespace }} generic {{ include "vpa.fullname" . }}-tls-certs --from-file=${TMP_DIR}/caKey.pem --from-file=${TMP_DIR}/caCert.pem --from-file=${TMP_DIR}/serverKey.pem --from-file=${TMP_DIR}/serverCert.pem
 
             # Clean up after we're done.
             echo "Deleting ${TMP_DIR}."

--- a/helm/vertical-pod-autoscaler-app/templates/admission-controller-cleanup.yaml
+++ b/helm/vertical-pod-autoscaler-app/templates/admission-controller-cleanup.yaml
@@ -66,5 +66,5 @@ spec:
             # From https://github.com/kubernetes/autoscaler/blob/vertical-pod-autoscaler-0.8.0/vertical-pod-autoscaler/pkg/admission-controller/delete-webhook.sh
             echo "Unregistering VPA admission controller webhook"
             kubectl delete -n {{ .Release.Namespace}} mutatingwebhookconfiguration.v1beta1.admissionregistration.k8s.io vpa-webhook-config || true
-            kubectl delete -n {{ .Release.Namespace}} secret vpa-tls-certs || true
+            kubectl delete -n {{ .Release.Namespace}} secret {{ include "vpa.fullname" . }}-tls-certs || true
 {{- end }}

--- a/helm/vertical-pod-autoscaler-app/templates/admission-controller-deployment.yaml
+++ b/helm/vertical-pod-autoscaler-app/templates/admission-controller-deployment.yaml
@@ -88,7 +88,7 @@ spec:
       volumes:
         - name: tls-certs
           secret:
-            secretName: vpa-tls-certs
+            secretName: {{ include "vpa.fullname" . }}-tls-certs
             {{- with .Values.admissionController.tlsSecretKeys }}
             items:
               {{- toYaml . | nindent 14 }}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/21463

Found out that the generated secret still had a `vpa-` prefix, which feel off as all other resources are prefixed with the release name.
Also found that the generated certificate was wrong because it embedded the wrong webhook service name.