### PR TITLE
Use patched docker image tagged `0.10.0-oomfix` for `recommender` and updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use patched docker image tagged `0.10.0-oomfix` for `recommender` and updater (see https://github.com/giantswarm/roadmap/issues/923).
+
 ## [2.3.0] - 2022-05-10
 
 ### Changed

--- a/helm/vertical-pod-autoscaler-app/values.yaml
+++ b/helm/vertical-pod-autoscaler-app/values.yaml
@@ -48,7 +48,7 @@ recommender:
     # recommender.image.pullPolicy -- The pull policy for the recommender image. Recommend not changing this
     pullPolicy: IfNotPresent
     # recommender.image.tag -- Overrides the image tag whose default is the chart appVersion
-    tag: ""
+    tag: "0.10.0-oomfix"
   # recommender.podAnnotations -- Annotations to add to the recommender pod
   podAnnotations: {}
   # recommender.podLabels -- Labels to add to the recommender pod
@@ -90,7 +90,7 @@ updater:
     # updater.image.pullPolicy -- The pull policy for the updater image. Recommend not changing this
     pullPolicy: IfNotPresent
     # updater.image.tag -- Overrides the image tag whose default is the chart appVersion
-    tag: ""
+    tag: "0.10.0-oomfix"
   # updater.podAnnotations -- Annotations to add to the updater pod
   podAnnotations: {}
   # updater.podLabels -- Labels to add to the updater pod


### PR DESCRIPTION
see https://github.com/giantswarm/roadmap/issues/923

This PR uses a custom built docker image for VPA updater and recommender components to circumvent a containerd bug in detecting OOMs