### PR TITLE
Bump 0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,14 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added validation - CPU values will be accepted only with resolution of 1 mCPU, memory with resolution of 1 b
 
   Other changes:
-
-    Switch to go 1.16
-
-    Admission controller now logs when it fails to start
-
-    Increase resolution of admission_latency_seconds metric
-
-    Reduce verbosity of some logs
+    - Switch to go 1.16
+    - Admission controller now logs when it fails to start
+    - Increase resolution of admission_latency_seconds metric
+    - Reduce verbosity of some logs
 
 ## [2.4.1] - 2022-07-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Upgrade vertical-pod-autoscaler to [0.11.0](https://github.com/kubernetes/autoscaler/releases/tag/vertical-pod-autoscaler-0.11.0)
+
   Potentially breaking change:
+
     Added validation - CPU values will be accepted only with resolution of 1 mCPU, memory with resolution of 1 b
 
   Other changes:
+
     Switch to go 1.16
+
     Admission controller now logs when it fails to start
+
     Increase resolution of admission_latency_seconds metric
+
     Reduce verbosity of some logs
 
 ## [2.4.1] - 2022-07-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped to upstream version 0.11.0.
+
 ## [2.4.1] - 2022-07-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade vertical-pod-autoscaler to [0.11.0](https://github.com/kubernetes/autoscaler/releases/tag/vertical-pod-autoscaler-0.11.0)
 
   Potentially breaking change:
-
-    Added validation - CPU values will be accepted only with resolution of 1 mCPU, memory with resolution of 1 b
+  - Added validation - CPU values will be accepted only with resolution of 1 mCPU, memory with resolution of 1 b
 
   Other changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bumped to upstream version 0.11.0.
+- Upgrade vertical-pod-autoscaler to [0.11.0](https://github.com/kubernetes/autoscaler/releases/tag/vertical-pod-autoscaler-0.11.0)
+  Potentially breaking change:
+    Added validation - CPU values will be accepted only with resolution of 1 mCPU, memory with resolution of 1 b
+
+  Other changes:
+    Switch to go 1.16
+    Admission controller now logs when it fails to start
+    Increase resolution of admission_latency_seconds metric
+    Reduce verbosity of some logs
 
 ## [2.4.1] - 2022-07-05
 

--- a/helm/vertical-pod-autoscaler-app/Chart.yaml
+++ b/helm/vertical-pod-autoscaler-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.10.0
+appVersion: 0.11.0
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
 home: https://github.com/giantswarm/vertical-pod-autoscaler-app
 maintainers:

--- a/helm/vertical-pod-autoscaler-app/values.yaml
+++ b/helm/vertical-pod-autoscaler-app/values.yaml
@@ -48,7 +48,7 @@ recommender:
     # recommender.image.pullPolicy -- The pull policy for the recommender image. Recommend not changing this
     pullPolicy: IfNotPresent
     # recommender.image.tag -- Overrides the image tag whose default is the chart appVersion
-    tag: "0.10.0-oomfix"
+    tag: ""
   # recommender.podAnnotations -- Annotations to add to the recommender pod
   podAnnotations: {}
   # recommender.podLabels -- Labels to add to the recommender pod
@@ -90,7 +90,7 @@ updater:
     # updater.image.pullPolicy -- The pull policy for the updater image. Recommend not changing this
     pullPolicy: IfNotPresent
     # updater.image.tag -- Overrides the image tag whose default is the chart appVersion
-    tag: "0.10.0-oomfix"
+    tag: ""
   # updater.podAnnotations -- Annotations to add to the updater pod
   podAnnotations: {}
   # updater.podLabels -- Labels to add to the updater pod


### PR DESCRIPTION
Tested with latest flatcar, and containers' OOMs are detected correctly:

```
Containers:
  oomtester:
    ...
    Last State:     Terminated
      Reason:       OOMKilled
      Exit Code:    137
      Started:      Mon, 25 Jul 2022 16:56:41 +0200
      Finished:     Mon, 25 Jul 2022 16:57:08 +0200
    Ready:          True
    Restart Count:  1
```

Also VPA is detecting the event just fine:
```
I0725 14:59:45.845672       1 cluster_feeder.go:467] OOM detected {Timestamp:2022-07-25 14:58:18 +0000 UTC Memory:52428800 ContainerID:{PodID:{Namespace:default PodName:oomtester-tfxqw} ContainerName:oomtester}}
```
