### PR TITLE
Add icon to Chart.yml for happa

### DIFF
--- a/helm/vertical-pod-autoscaler-app/Chart.yaml
+++ b/helm/vertical-pod-autoscaler-app/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
 appVersion: 0.11.0
 description: A Helm chart for Kubernetes Vertical Pod Autoscaler
+icon: https://s.giantswarm.io/app-icons/k8s-initiator/1/dark.svg
 home: https://github.com/giantswarm/vertical-pod-autoscaler-app
 maintainers:
 - name: sudermanjr


### PR DESCRIPTION
For https://github.com/giantswarm/roadmap/issues/1248

Don't be confused by `k8s-initiator`. We are reusing existing icons and that is just the Kubernetes icon.