### PR TITLE
Run on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Run the CRD patch job in master nodes and tolerate not ready nodes.
+- Run the certgen job in master nodes and tolerate not ready nodes.
 
 ## [2.5.0] - 2022-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Run the CRD patch job in master nodes and tolerate not ready nodes.
+
 ## [2.5.0] - 2022-08-08
 
 ### Changed

--- a/helm/vertical-pod-autoscaler-app/Chart.yaml
+++ b/helm/vertical-pod-autoscaler-app/Chart.yaml
@@ -9,7 +9,7 @@ name: vertical-pod-autoscaler-app
 sources:
 - https://github.com/kubernetes/autoscaler
 type: application
-version: 1.2.3
+version: [[ .Version ]]
 annotations:
   repository: https://github.com/FairwindsOps/charts/tree/master/stable/vpa
   version: fb2ccec4228c26e366bd1ac96aade056f3db0151

--- a/helm/vertical-pod-autoscaler-app/Chart.yaml
+++ b/helm/vertical-pod-autoscaler-app/Chart.yaml
@@ -9,7 +9,7 @@ name: vertical-pod-autoscaler-app
 sources:
 - https://github.com/kubernetes/autoscaler
 type: application
-version: [[ .Version ]]
+version: 1.2.3
 annotations:
   repository: https://github.com/FairwindsOps/charts/tree/master/stable/vpa
   version: fb2ccec4228c26e366bd1ac96aade056f3db0151

--- a/helm/vertical-pod-autoscaler-app/templates/_helpers.tpl
+++ b/helm/vertical-pod-autoscaler-app/templates/_helpers.tpl
@@ -62,3 +62,14 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Returns the API server pods' listen pod based on the provider.
+*/}}
+{{- define "vpa.apiServerListenPort" -}}
+{{- if has .Values.provider (list "aws" "azure" "kvm") -}}
+443
+{{- else -}}
+6443
+{{- end -}}
+{{- end -}}

--- a/helm/vertical-pod-autoscaler-app/templates/admission-controller-certgen.yaml
+++ b/helm/vertical-pod-autoscaler-app/templates/admission-controller-certgen.yaml
@@ -127,6 +127,8 @@ spec:
         env:
           - name: KUBERNETES_SERVICE_HOST
             value: 127.0.0.1
+          - name: KUBERNETES_SERVICE_PORT
+            value: "{{ include "vpa.apiServerListenPort" . }}"
           {{- range $key, $value := .Values.admissionController.certGen.env }}
           - name: {{ $key }}
             value: {{ $value | quote }}

--- a/helm/vertical-pod-autoscaler-app/templates/admission-controller-certgen.yaml
+++ b/helm/vertical-pod-autoscaler-app/templates/admission-controller-certgen.yaml
@@ -58,6 +58,13 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node.kubernetes.io/not-ready
+          effect: NoSchedule
       containers:
       - name: certgen
         image: "{{ .Values.registry.domain }}/{{ .Values.admissionController.certGen.image.repository }}:{{ .Values.admissionController.certGen.image.tag }}"
@@ -117,6 +124,8 @@ spec:
             echo "Deleting ${TMP_DIR}."
             rm -rf ${TMP_DIR}
         env:
+          - name: KUBERNETES_SERVICE_HOST
+            value: 127.0.0.1
           {{- range $key, $value := .Values.admissionController.certGen.env }}
           - name: {{ $key }}
             value: {{ $value | quote }}

--- a/helm/vertical-pod-autoscaler-app/templates/admission-controller-certgen.yaml
+++ b/helm/vertical-pod-autoscaler-app/templates/admission-controller-certgen.yaml
@@ -60,6 +60,7 @@ spec:
       {{- end }}
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      hostNetwork: true
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule

--- a/helm/vertical-pod-autoscaler-app/templates/crd-patch/crd-job.yaml
+++ b/helm/vertical-pod-autoscaler-app/templates/crd-patch/crd-job.yaml
@@ -23,12 +23,19 @@ spec:
       securityContext:
         runAsUser: 2000
         runAsGroup: 2000
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
       tolerations:
       - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      - key: node.kubernetes.io/not-ready
         effect: NoSchedule
       containers:
       - name: kubectl
         image: "{{ .Values.image.registry }}/giantswarm/docker-kubectl:latest"
+        env:
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         command:
         - sh
         - -c

--- a/helm/vertical-pod-autoscaler-app/templates/crd-patch/crd-job.yaml
+++ b/helm/vertical-pod-autoscaler-app/templates/crd-patch/crd-job.yaml
@@ -37,6 +37,8 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: KUBERNETES_SERVICE_PORT
+          value: "{{ include "vpa.apiServerListenPort" . }}"
         command:
         - sh
         - -c

--- a/helm/vertical-pod-autoscaler-app/templates/crd-patch/crd-job.yaml
+++ b/helm/vertical-pod-autoscaler-app/templates/crd-patch/crd-job.yaml
@@ -25,6 +25,7 @@ spec:
         runAsGroup: 2000
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      hostNetwork: true
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule

--- a/helm/vertical-pod-autoscaler-app/templates/crd-patch/crd-psp.yaml
+++ b/helm/vertical-pod-autoscaler-app/templates/crd-patch/crd-psp.yaml
@@ -24,6 +24,7 @@ spec:
         max: 65535
   volumes:
   - 'configMap'
+  - 'projected'
   hostPID: false
   hostIPC: false
   hostNetwork: true

--- a/helm/vertical-pod-autoscaler-app/templates/crd-patch/crd-psp.yaml
+++ b/helm/vertical-pod-autoscaler-app/templates/crd-patch/crd-psp.yaml
@@ -26,7 +26,7 @@ spec:
   - 'configMap'
   hostPID: false
   hostIPC: false
-  hostNetwork: false
+  hostNetwork: true
   fsGroup:
     rule: 'MustRunAs'
     ranges:

--- a/helm/vertical-pod-autoscaler-app/values.yaml
+++ b/helm/vertical-pod-autoscaler-app/values.yaml
@@ -187,3 +187,8 @@ admissionController:
 isManagementCluster: false
 registry:
   domain: docker.io
+
+# provider (aws|kvm|azure|gcp|capa)
+# The provider that the cluster is running on.
+# This value is set automatically, Do not overwrite this value.
+provider: ""


### PR DESCRIPTION
When creating a new WC, the order in which `Apps` are installed is random and unpredictable.
It might happen that VPA app is installed before `cilium`, thus trying to run in a cluster which is fundamentally not working (no CNI).
This Chart has 2 jobs that run as hooks on helm release creation: `certgen` and `crd-patch`.
Those jobs can't run if the cluster is not ready and the `helm install` operation hangs for several minutes (sometimes even half an hour) blocking installation of other applications and causing a lot of trouble.

Now, the 2 jobs only require to talk to the API server to do what they're meant to do, so they not need any CNI or working cluster, but really just a working API server.

This PR makes the following changes to the 2 jobs:

- run on host network
- run on master nodes only
- tolerate notReady taint
- add 2 env variables to reach API server on localhost

with this trick, the jobs can safely run even on very broken clusters and chart installation time is dramatically improved.

Now, I understand this is hacky, but considering those are one-off jobs we could accept them.

WDYT?