### PR TITLE
Ignore error when updating openssl in container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Adding `application.giantswarm.io/team` label to kubernetes resources
+- Ignore error when updating openssl in `vertical-pod-autoscaler-certgen` container (private environment)
 
 ## [2.5.0] - 2022-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Adding `application.giantswarm.io/team` label to kubernetes resources
-- Ignore error when updating openssl in `vertical-pod-autoscaler-certgen` container (private environment)
+- Removing openssl update in `vertical-pod-autoscaler-certgen` container
 
 ## [2.5.0] - 2022-08-08
 

--- a/helm/vertical-pod-autoscaler-app/templates/admission-controller-certgen.yaml
+++ b/helm/vertical-pod-autoscaler-app/templates/admission-controller-certgen.yaml
@@ -72,7 +72,6 @@ spec:
             set -o errexit
             set -o nounset
             set -o pipefail
-            apk --update add openssl || true
             CN_BASE="vpa_webhook"
             TMP_DIR="/tmp/vpa-certs"
 

--- a/helm/vertical-pod-autoscaler-app/templates/admission-controller-certgen.yaml
+++ b/helm/vertical-pod-autoscaler-app/templates/admission-controller-certgen.yaml
@@ -72,7 +72,7 @@ spec:
             set -o errexit
             set -o nounset
             set -o pipefail
-            apk --update add openssl
+            apk --update add openssl || true
             CN_BASE="vpa_webhook"
             TMP_DIR="/tmp/vpa-certs"
 


### PR DESCRIPTION
towards https://github.com/giantswarm/roadmap/issues/1673.

For private environment (no internet access), we decided to ignore error on this command executed in the container `vertical-pod-autoscaler-certgen`:
```
apk --update add openssl
```

Hence, for other installations, the behaviour remains the same as upstream manifest:
https://artifacthub.io/packages/helm/fairwinds-stable/vpa?modal=template&template=admission-controller-certgen.yaml
