### PR TITLE
Using custom docker image with openssl to fix vpa-certgen job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Using custom docker image with openssl to fix vpa-certgen job
+
 ## [2.5.1] - 2022-11-29
 
 ### Changed

--- a/helm/vertical-pod-autoscaler-app/values.yaml
+++ b/helm/vertical-pod-autoscaler-app/values.yaml
@@ -126,7 +126,7 @@ admissionController:
       # admissionController.certGen.image.repository -- An image that contains certgen for creating certificates. Only used if admissionController.generateCertificate is true
       repository: giantswarm/vpa-certgen-ci-images
       # admissionController.certGen.image.tag -- An image tag for the admissionController.certGen.image.repository image. Only used if admissionController.generateCertificate is true
-      tag: v11-alpine
+      tag: v11-alpine-openssl
       # admissionController.certGen.image.pullPolicy -- The pull policy for the certgen image. Recommend not changing this
       pullPolicy: IfNotPresent
       # admissionController.certGen.env -- Additional environment variables to be added to the certgen container. Format is KEY: Value format
@@ -140,7 +140,7 @@ admissionController:
       # admissionController.cleanupOnDelete.image.repository -- The repository of the post-delete image
       repository: giantswarm/vpa-certgen-ci-images
       # admissionController.cleanupOnDelete.image.tag -- The image tag to use for the admission controller cleanup image
-      tag: v11-alpine
+      tag: v11-alpine-openssl
   # admissionController.replicaCount -- The amount admission-controller pods which should run
   replicaCount: 2
   # admissionController.podDisruptionBudget -- This is the setting for the pod disruption budget


### PR DESCRIPTION
towards https://github.com/giantswarm/roadmap/issues/1673

In private environment, we don't have internet access and we can't execute command like `apk add` in container.
To avoid this, we have created a custom tag for `vpa-certgen-ci-image` with openssl package installed.

This PR is for using this custom tag in manifests.