### PR TITLE
Add cilium netpol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add cilium network policy so that the crd-install job can reach the k8s api to install the CRDs.
+
 ### Changed
 
-- Remove `push-to-app-collection` jobs for onprem providers since this app became a part of default apps bundle. 
+- Remove `push-to-app-collection` jobs for onprem providers since this app became a part of default apps bundle.
 
 ## [2.5.3] - 2023-01-10
 

--- a/helm/vertical-pod-autoscaler-app/templates/crd-patch/crd-cilium-np.yaml
+++ b/helm/vertical-pod-autoscaler-app/templates/crd-patch/crd-cilium-np.yaml
@@ -1,0 +1,29 @@
+{{- if .Capabilities.APIVersions.Has "cilium.io/v2" }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ include "vpa.fullname" . }}-crd-patch
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    # create hook dependencies in the right order
+    "helm.sh/hook-weight": "-4"
+    # run only on upgrade
+    "helm.sh/hook": "pre-upgrade"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+  labels:
+    app.kubernetes.io/component: {{ include "vpa.fullname" . }}-crd-patch
+    {{- include "vpa.selectorLabels" . | nindent 4 }}
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/component: {{ include "vpa.fullname" . }}-crd-patch
+      {{- include "vpa.selectorLabels" . | nindent 4 }}
+  egress:
+    - toEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "443"
+        - ports:
+            - port: "6443"
+{{- end }}

--- a/helm/vertical-pod-autoscaler-app/templates/crd-patch/crd-job.yaml
+++ b/helm/vertical-pod-autoscaler-app/templates/crd-patch/crd-job.yaml
@@ -8,7 +8,7 @@ metadata:
     "helm.sh/hook-weight": "-1"
     # run only on upgrade
     "helm.sh/hook": "pre-upgrade"
-    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
     app.kubernetes.io/component: {{ include "vpa.fullname" . }}-crd-patch
     {{- include "vpa.selectorLabels" . | nindent 4 }}

--- a/helm/vertical-pod-autoscaler-app/templates/crd-patch/crd-np.yaml
+++ b/helm/vertical-pod-autoscaler-app/templates/crd-patch/crd-np.yaml
@@ -8,7 +8,7 @@ metadata:
     "helm.sh/hook-weight": "-7"
     # run only on upgrade
     "helm.sh/hook": "pre-upgrade"
-    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
     app.kubernetes.io/component: {{ include "vpa.fullname" . }}-crd-patch
     {{- include "vpa.selectorLabels" . | nindent 4 }}

--- a/helm/vertical-pod-autoscaler-app/templates/crd-patch/crd-psp.yaml
+++ b/helm/vertical-pod-autoscaler-app/templates/crd-patch/crd-psp.yaml
@@ -7,7 +7,7 @@ metadata:
     "helm.sh/hook-weight": "-6"
     # run only on upgrade
     "helm.sh/hook": "pre-upgrade"
-    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
     app.kubernetes.io/component: {{ include "vpa.fullname" . }}-crd-patch
     {{- include "vpa.selectorLabels" . | nindent 4 }}

--- a/helm/vertical-pod-autoscaler-app/templates/crd-patch/crd-rbac.yaml
+++ b/helm/vertical-pod-autoscaler-app/templates/crd-patch/crd-rbac.yaml
@@ -8,7 +8,7 @@ metadata:
     "helm.sh/hook-weight": "-3"
     # run only on upgrade
     "helm.sh/hook": "pre-upgrade"
-    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
     app.kubernetes.io/component: {{ include "vpa.fullname" . }}-crd-patch
     {{- include "vpa.selectorLabels" . | nindent 4 }}

--- a/helm/vertical-pod-autoscaler-app/templates/crd-patch/crd-serviceaccount.yaml
+++ b/helm/vertical-pod-autoscaler-app/templates/crd-patch/crd-serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
     "helm.sh/hook-weight": "-4"
     # run only on upgrade
     "helm.sh/hook": "pre-upgrade"
-    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
     app.kubernetes.io/component: {{ include "vpa.fullname" . }}-crd-patch
     {{- include "vpa.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
On CAPI clusters we use `cilium` and the netpols that use `ipblock` won't work, so we need to add a cilium netpol. This PR is basically the same as this one we did for [prometheus operator](https://github.com/giantswarm/prometheus-operator-app/pull/214).