### PR TITLE
Do ont create PDB for recommender and updater since we only set a replica of 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Disable PDB for recommender and updater since we only run 1 replica of those pods. 
+
 ## [3.4.0] - 2023-04-04
 
 ### Added

--- a/helm/vertical-pod-autoscaler-app/values.yaml
+++ b/helm/vertical-pod-autoscaler-app/values.yaml
@@ -62,15 +62,15 @@ vertical-pod-autoscaler:
 
   recommender:
     replicaCount: 1
+    # Do not create PDB when replica is 1
+    pdb:
+      create: false
 
     image:
       registry: docker.io
       repository: giantswarm/vpa-recommender
       tag: 0.13.0
       pullPolicy: IfNotPresent
-
-    pdb:
-      create: true
 
     podSecurityContext:
       runAsNonRoot: true
@@ -119,15 +119,15 @@ vertical-pod-autoscaler:
     enabled: true
 
     replicaCount: 1
+    # Do not create PDB when replica is 1
+    pdb:
+      create: false
 
     image:
       registry: docker.io
       repository: giantswarm/vpa-updater
       tag: 0.13.0
       pullPolicy: IfNotPresent
-
-    pdb:
-      create: true
 
     podSecurityContext:
       runAsNonRoot: true


### PR DESCRIPTION
this causes capi roll restart of nodes to get stuck like

```
capi-controller-manager-6548585ff9-5cmvj manager E0405 12:36:04.414088       1 machine_controller.go:619] "error when evicting pods/\"vertical-pod-autoscaler-updater-748cc7d65d-lq9wq\" -n \"kube-system\" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.\n" controller="machine" controllerGroup="cluster.x-k8s.io" controllerKind="Machine" Machine="org-giantswarm/cuckoo-md00-6bc778b455-m95gk" namespace="org-giantswarm" name="cuckoo-md00-6bc778b455-m95gk" reconcileID=591059ae-b64b-4bf6-9021-9da6a57be679 MachineSet="org-giantswarm/cuckoo-md00-6bc778b455" MachineDeployment="org-giantswarm/cuckoo-md00" Cluster="org-giantswarm/cuckoo" Node="cuckoo-md00-df6ca110-b24qz"
```
