### PR TITLE
Remove shared collection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,22 +46,6 @@ workflows:
 
       - architect/push-to-app-collection:
           context: architect
-          name: shared-app-collection
-          app_catalog: control-plane-catalog
-          app_name: vertical-pod-autoscaler-app
-          app_namespace: giantswarm
-          app_collection_repo: shared-app-collection
-          disable_force_upgrade: true
-          requires:
-            - control-plane-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
-
-      - architect/push-to-app-collection:
-          context: architect
           name: aws-app-collection
           app_catalog: control-plane-catalog
           app_name: vertical-pod-autoscaler-app

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove circleci job for pushing to shared app collection
+
 ## [3.4.1] - 2023-04-05
 
 ### Changed


### PR DESCRIPTION
Following the announcement of shared app collection archiving, this PR removes the circleci job pushing to this collection.