### PR TITLE
Add pod Annotation for `cluster-autoscaler safe-to-evict`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `cluster-autoscaler safe-to-evict` annotation to `recommender` and `updater`
+
 ## [3.5.1] - 2023-06-14
 
 ### Changed

--- a/helm/vertical-pod-autoscaler-app/values.yaml
+++ b/helm/vertical-pod-autoscaler-app/values.yaml
@@ -69,6 +69,9 @@ vertical-pod-autoscaler:
     # Do not create PDB when replica is 1
     pdb:
       create: false
+    # When using single replica we need to annotate the pod for Cluster Autoscaler to allow eviction in kube-system namespace
+    podAnnotations:
+      cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
 
     image:
       registry: docker.io
@@ -130,6 +133,9 @@ vertical-pod-autoscaler:
     # Do not create PDB when replica is 1
     pdb:
       create: false
+    # When using single replica we need to annotate the pod for Cluster Autoscaler to allow eviction in kube-system namespace
+    podAnnotations:
+      cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
 
     image:
       registry: docker.io


### PR DESCRIPTION
Towards https://github.com/giantswarm/vodafone/issues/617

Add `cluster-autoscaler` `safe-to-evict` annotation to `recommender` and `updater` pods
so that , since we run those pods in kube-system, they will be evicted by cluster-autoscaler
if a node needs to be reclaimed
