### PR TITLE
Increase default limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+
+- Raised limits for all components.
+
 ## [3.5.1] - 2023-06-14
 
 ### Changed

--- a/helm/vertical-pod-autoscaler-app/values.yaml
+++ b/helm/vertical-pod-autoscaler-app/values.yaml
@@ -48,7 +48,7 @@ vertical-pod-autoscaler:
         - cpu
         - memory
         maxAllowed:
-          cpu: 50m
+          cpu: 200m
           memory: 3000Mi
         minAllowed:
           cpu: 50m

--- a/helm/vertical-pod-autoscaler-app/values.yaml
+++ b/helm/vertical-pod-autoscaler-app/values.yaml
@@ -35,8 +35,8 @@ vertical-pod-autoscaler:
 
     resources:
       limits:
-        cpu: 50m
-        memory: 250Mi
+        cpu: 100m
+        memory: 2000Mi
       requests:
         cpu: 50m
         memory: 200Mi
@@ -48,7 +48,7 @@ vertical-pod-autoscaler:
         - cpu
         - memory
         maxAllowed:
-          cpu: 200m
+          cpu: 50m
           memory: 3000Mi
         minAllowed:
           cpu: 50m
@@ -93,7 +93,7 @@ vertical-pod-autoscaler:
     resources:
       limits:
         cpu: 100m
-        memory: 300Mi
+        memory: 2000Mi
       requests:
         cpu: 100m
         memory: 250Mi
@@ -154,7 +154,7 @@ vertical-pod-autoscaler:
     resources:
       limits:
         cpu: 100m
-        memory: 300Mi
+        memory: 2000Mi
       requests:
         cpu: 100m
         memory: 250Mi

--- a/helm/vertical-pod-autoscaler-app/values.yaml
+++ b/helm/vertical-pod-autoscaler-app/values.yaml
@@ -35,7 +35,7 @@ vertical-pod-autoscaler:
 
     resources:
       limits:
-        cpu: 100m
+        cpu: 50m
         memory: 2000Mi
       requests:
         cpu: 50m


### PR DESCRIPTION
Increase default limits to avoid chicken-egg issue while it's OOM itself and can't scale up.

Related PMs:
* https://github.com/giantswarm/giantswarm/issues/27023
* https://github.com/giantswarm/giantswarm/issues/27250