### PR TITLE
fix job-name label in cilium netpol for crd patch job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix unallowed `job-name` label in Cilium network policy for crd patch job.
+
 ## [3.5.4] - 2023-08-03
 
 ### Changed

--- a/helm/vertical-pod-autoscaler-app/templates/crd-patch/cilium-np.yaml
+++ b/helm/vertical-pod-autoscaler-app/templates/crd-patch/cilium-np.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   endpointSelector:
     matchLabels:
-      job-name: vpa-remove-crd-ownership
+      app.kubernetes.io/component: crd-removal
   egress:
     - toEntities:
         - kube-apiserver

--- a/helm/vertical-pod-autoscaler-app/templates/crd-patch/remove-crd-ownership-job.yaml
+++ b/helm/vertical-pod-autoscaler-app/templates/crd-patch/remove-crd-ownership-job.yaml
@@ -11,6 +11,10 @@ metadata:
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
   template:
+    metadata:
+      labels:
+        {{- include "vertical-pod-autoscaler.labels" . | nindent 8 }}
+        app.kubernetes.io/component: crd-removal
     spec:
       serviceAccountName: vpa-annotate-job-sa
       containers:


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/27668

Replace the unallowed `job-name` label in Cilium networkpolicy for crd patch job.