### PR TITLE
Revert chart dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Revert chart dependency to `9.3.0`.
+
 ## [4.4.0] - 2023-10-27
 
 ### Changed

--- a/helm/vertical-pod-autoscaler-app/Chart.yaml
+++ b/helm/vertical-pod-autoscaler-app/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/cowboysysop/charts/blob/master/charts/vertical-pod-autoscaler/
 dependencies:
   - name: vertical-pod-autoscaler
-    version: 9.4.0
+    version: 9.3.0
     repository: https://cowboysysop.github.io/charts/
 type: application
 version: 4.4.0


### PR DESCRIPTION
Reverting https://github.com/giantswarm/vertical-pod-autoscaler-app/pull/229. 

This PR bumps VPA to `v1.0.0` pre-release which was hard to detect. For now we should wait until upstream officially releases VPA `v1.0.0`.