### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,6 @@ WARNING: this version requires Cilium to run because of the dependency on the Ci
 - Upgrade dependency chart to 7.1.0.
 - Upgrade VPA components to 0.14.0
 
-
 ## [3.5.3] - 2023-06-28
 
 ### Added
@@ -361,3 +360,9 @@ alerts.
 [1.0.2]: https://github.com/giantswarm/vertical-pod-autoscaler-app/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/giantswarm/vertical-pod-autoscaler-app/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/giantswarm/vertical-pod-autoscaler-app/releases/tag/v1.0.0
+
+## [Unreleased]
+
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.

--- a/helm/vertical-pod-autoscaler-app/values.yaml
+++ b/helm/vertical-pod-autoscaler-app/values.yaml
@@ -1,5 +1,5 @@
 global:
-  imageRegistry: docker.io
+  imageRegistry: gsoci.azurecr.io
 
 vertical-pod-autoscaler:
   nameOverride: ""
@@ -9,7 +9,7 @@ vertical-pod-autoscaler:
     enabled: true
 
     image:
-      registry: docker.io
+      registry: gsoci.azurecr.io
       repository: giantswarm/vpa-admission-controller
       tag: 1.0.0
       pullPolicy: IfNotPresent
@@ -44,8 +44,8 @@ vertical-pod-autoscaler:
       enabled: false
       containerPolicies:
         controlledResources:
-        - cpu
-        - memory
+          - cpu
+          - memory
         minAllowed:
           cpu: 200m
           memory: 250Mi
@@ -72,7 +72,7 @@ vertical-pod-autoscaler:
       cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
 
     image:
-      registry: docker.io
+      registry: gsoci.azurecr.io
       repository: giantswarm/vpa-recommender
       tag: 1.0.0
       pullPolicy: IfNotPresent
@@ -116,8 +116,8 @@ vertical-pod-autoscaler:
       enabled: false
       containerPolicies:
         controlledResources:
-        - cpu
-        - memory
+          - cpu
+          - memory
         minAllowed:
           cpu: 250m
           memory: 250Mi
@@ -159,7 +159,7 @@ vertical-pod-autoscaler:
       cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
 
     image:
-      registry: docker.io
+      registry: gsoci.azurecr.io
       repository: giantswarm/vpa-updater
       tag: 1.0.0
       pullPolicy: IfNotPresent
@@ -199,8 +199,8 @@ vertical-pod-autoscaler:
       enabled: false
       containerPolicies:
         controlledResources:
-        - cpu
-        - memory
+          - cpu
+          - memory
         minAllowed:
           cpu: 250m
           memory: 250Mi
@@ -220,7 +220,7 @@ vertical-pod-autoscaler:
 
   crds:
     image:
-      registry: docker.io
+      registry: gsoci.azurecr.io
       repository: giantswarm/kubectl
       tag: 1.28.4
 


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
