### PR TITLE
Update to VPA v1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
+### Changed
+
+- Chart: Update `appVersion` and `README.md`, VPA v1.1.2. ([#293](https://github.com/giantswarm/vertical-pod-autoscaler-app/pull/293))
+
 ## [5.2.1] - 2024-04-11
 
 ### Changed

--- a/helm/vertical-pod-autoscaler-app/Chart.yaml
+++ b/helm/vertical-pod-autoscaler-app/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: vertical-pod-autoscaler-app
 description: A Helm chart for the Vertical Pod Autoscaler.
-version: 5.2.1
-appVersion: 1.1.0
+version: 5.2.2
+appVersion: 1.1.2
 home: https://github.com/giantswarm/vertical-pod-autoscaler-app
 icon: https://s.giantswarm.io/app-icons/k8s-initiator/1/dark.svg
 annotations:

--- a/helm/vertical-pod-autoscaler-app/README.md
+++ b/helm/vertical-pod-autoscaler-app/README.md
@@ -1,6 +1,6 @@
 # vertical-pod-autoscaler-app
 
-![Version: 5.2.1](https://img.shields.io/badge/Version-5.2.1-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 5.2.2](https://img.shields.io/badge/Version-5.2.2-informational?style=flat-square) ![AppVersion: 1.1.2](https://img.shields.io/badge/AppVersion-1.1.2-informational?style=flat-square)
 
 A Helm chart for the Vertical Pod Autoscaler.
 
@@ -10,7 +10,7 @@ A Helm chart for the Vertical Pod Autoscaler.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://cowboysysop.github.io/charts | vertical-pod-autoscaler | 9.8.0 |
+| https://cowboysysop.github.io/charts | vertical-pod-autoscaler | 9.8.2 |
 
 ## Values
 


### PR DESCRIPTION
Following https://github.com/giantswarm/vertical-pod-autoscaler-app/pull/292, updates docs and chart to latest version.

VPA 1.1.2 solves the crashes we were experiencing with VPA 1.1.0 and 1.1.1 ( https://github.com/giantswarm/roadmap/issues/3421)


Tested on a new cluster: VPA updater v1.1.1 crashes after ~60 seconds when looping through resources, VPA updater v1.1.2 does not crash. 