### PR TITLE
Change `restartPolicy` to `OnFailure` for the CRD job.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
+### Changed
+
+- Chart: Change `restartPolicy` to `OnFailure` for the CRD job. ([#298](https://github.com/giantswarm/vertical-pod-autoscaler-app/pull/298))
+
 ## [5.2.2] - 2024-05-21
 
 ### Changed

--- a/helm/vertical-pod-autoscaler-app/templates/crd-patch/job.yaml
+++ b/helm/vertical-pod-autoscaler-app/templates/crd-patch/job.yaml
@@ -31,4 +31,5 @@ spec:
           {{- toYaml (index .Values "vertical-pod-autoscaler").crds.securityContext | nindent 10 }}
       securityContext:
         {{- toYaml (index .Values "vertical-pod-autoscaler").crds.podSecurityContext | nindent 8 }}
-      restartPolicy: Never
+      restartPolicy: OnFailure
+  backoffLimit: 3


### PR DESCRIPTION
To make the CRD job invoked through helm hooks more reliable, change `restartPolicy` to `onFailure` (with a backoffLimit of 3). 