### PR TITLE
Add podSecurityContext in values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
+### Changed
+
+- Chart: Add explicit podSecurityContext in values. ([#300](https://github.com/giantswarm/vertical-pod-autoscaler-app/pull/300))
+
 ## [5.2.3] - 2024-06-25
 
 ### Changed

--- a/helm/vertical-pod-autoscaler-app/values.schema.json
+++ b/helm/vertical-pod-autoscaler-app/values.schema.json
@@ -62,6 +62,23 @@
                                 }
                             }
                         },
+                        "podSecurityContext": {
+                            "type": "object",
+                            "properties": {
+                                "runAsGroup": {
+                                    "type": "integer",
+                                    "default": 65534
+                                },
+                                "runAsNonRoot": {
+                                    "type": "boolean",
+                                    "default": true
+                                },
+                                "runAsUser": {
+                                    "type": "integer",
+                                    "default": 65534
+                                }
+                            }
+                        },
                         "replicaCount": {
                             "type": "integer"
                         },
@@ -171,6 +188,23 @@
                                 }
                             }
                         },
+                        "podSecurityContext": {
+                            "type": "object",
+                            "properties": {
+                                "runAsGroup": {
+                                    "type": "integer",
+                                    "default": 65534
+                                },
+                                "runAsNonRoot": {
+                                    "type": "boolean",
+                                    "default": true
+                                },
+                                "runAsUser": {
+                                    "type": "integer",
+                                    "default": 65534
+                                }
+                            }
+                        },
                         "securityContext": {
                             "type": "object",
                             "properties": {
@@ -275,6 +309,23 @@
                             "properties": {
                                 "cluster-autoscaler.kubernetes.io/safe-to-evict": {
                                     "type": "string"
+                                }
+                            }
+                        },
+                        "podSecurityContext": {
+                            "type": "object",
+                            "properties": {
+                                "runAsGroup": {
+                                    "type": "integer",
+                                    "default": 65534
+                                },
+                                "runAsNonRoot": {
+                                    "type": "boolean",
+                                    "default": true
+                                },
+                                "runAsUser": {
+                                    "type": "integer",
+                                    "default": 65534
                                 }
                             }
                         },
@@ -433,6 +484,23 @@
                             "properties": {
                                 "cluster-autoscaler.kubernetes.io/safe-to-evict": {
                                     "type": "string"
+                                }
+                            }
+                        },
+                        "podSecurityContext": {
+                            "type": "object",
+                            "properties": {
+                                "runAsGroup": {
+                                    "type": "integer",
+                                    "default": 65534
+                                },
+                                "runAsNonRoot": {
+                                    "type": "boolean",
+                                    "default": true
+                                },
+                                "runAsUser": {
+                                    "type": "integer",
+                                    "default": 65534
                                 }
                             }
                         },

--- a/helm/vertical-pod-autoscaler-app/values.yaml
+++ b/helm/vertical-pod-autoscaler-app/values.yaml
@@ -27,6 +27,12 @@ vertical-pod-autoscaler:
       ## @param admissionController.pdb.create Specifies whether a pod disruption budget should be created
       create: true
 
+    ## @param admissionController.podSecurityContext Pod security context
+    podSecurityContext:
+      runAsGroup: 65534
+      runAsNonRoot: true
+      runAsUser: 65534
+
     ## @param admissionController.securityContext Container security context
     securityContext:
       allowPrivilegeEscalation: false
@@ -82,6 +88,12 @@ vertical-pod-autoscaler:
     ## @param recommender.podAnnotations Additional pod annotations
     podAnnotations:
       cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+
+    ## @param recommender.podSecurityContext Pod security context
+    podSecurityContext:
+      runAsGroup: 65534
+      runAsNonRoot: true
+      runAsUser: 65534
 
     ## @param recommender.securityContext Container security context
     securityContext:
@@ -169,6 +181,12 @@ vertical-pod-autoscaler:
     podAnnotations:
       cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
 
+    ## @param updater.podSecurityContext Pod security context
+    podSecurityContext:
+      runAsGroup: 65534
+      runAsNonRoot: true
+      runAsUser: 65534
+
     ## @param updater.securityContext Container security context
     securityContext:
       allowPrivilegeEscalation: false
@@ -241,6 +259,12 @@ vertical-pod-autoscaler:
 
       ## @param crds.image.tag Image tag
       tag: 1.29.4
+
+    ## @param crds.podSecurityContext Pod security context
+    podSecurityContext:
+      runAsGroup: 65534
+      runAsNonRoot: true
+      runAsUser: 65534
 
     ## @param crds.securityContext Container security context
     securityContext:


### PR DESCRIPTION
Adds explicit defaults for the securityContext of pods of this app (previously `runAsUser: 65534` and `runAsNonRoot: true` were inherited from the default values of the upstream chart, `runAsGroup` was unset).

Towards: https://github.com/giantswarm/giantswarm/issues/31175